### PR TITLE
Fixing compatibility between numpy versions

### DIFF
--- a/NoiseSimCreateEcdf.py
+++ b/NoiseSimCreateEcdf.py
@@ -19,7 +19,7 @@ def merge(runnumber):
     name.sort()
     for n in name:
         print(n)
-        data = np.load(n)
+        data = np.load(n,allow_pickle=True)
         arrays.append(data)
         del data
     N = name[0].split('_N')[1].split('.')[0]


### PR DESCRIPTION
As you can see below, before 1.16.3 the default value of **allow_pickle** was _True_.
Now to load an object array it needs to explicitly allow pickled data.

**allow_pickle bool, optional**
_

> Allow loading pickled object arrays stored in npy files. Reasons for disallowing pickles include security, as loading pickled data can execute arbitrary code. If pickles are disallowed, loading object arrays will fail. Default: FalseChanged in version 1.16.3: Made default False in response to CVE-2019-6446.

_